### PR TITLE
Added gulp install task, fixes #1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var replace = require('gulp-replace');
 var yargs = require('yargs');
 var path = require('path');
 var fs = require('fs');
+var shell = require('gulp-shell');
 
 var appPath = path.join(__dirname, 'build');
 
@@ -52,4 +53,8 @@ gulp.task('build-www', function() {
   return gulp.src('www/**/*')
     .pipe(gulp.dest('./build/www'));
 });
+
+gulp.task('install', shell.task([
+  'install-to-adb build/ --launch'
+]));
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "gulp-jshint": "^1.10.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
+    "gulp-shell": "^0.4.1",
+    "install-to-adb": "^1.1.0",
     "yargs": "^3.7.0"
   }
 }


### PR DESCRIPTION
So I've added gulp-shell, so that we can just have a straight "here's what I'd type into a shell to get it to work" workflow, but it might be better to make it more gulp-like, with a root `install-to-adb` action, and a directory argument filled with `build/`, and then a launch parameter defined somewhere.

My gulp-fu isn't strong enough to solve this right now, but I've tested running an `npm install` with my device connected, and it deploys and launches the application as expected. :)
